### PR TITLE
Construct pool on GL prototype

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,9 +6,9 @@ var Pool = require('generic-pool').Pool;
 var N_CPUS = require('os').cpus().length;
 
 module.exports = function(fileSource) {
-    if (!(fileSource instanceof mbgl.FileSource)) return callback(new Error('fileSource must be a FileSource object'));
-    if (typeof fileSource.request !== 'function') return callback(new Error("fileSource must have a 'request' method"));
-    if (typeof fileSource.cancel !== 'function') return callback(new Error("fileSource must have a 'cancel' method"));
+    if (!(fileSource instanceof mbgl.FileSource)) throw new Error('fileSource must be a FileSource object');
+    if (typeof fileSource.request !== 'function') throw new Error("fileSource must have a 'request' method");
+    if (typeof fileSource.cancel !== 'function') throw new Error("fileSource must have a 'cancel' method");
 
     GL.prototype._pool = pool(fileSource);
 

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -2,7 +2,7 @@
 
 /* jshint node:true */
 
-var GL = require('../index.js');
+var TileSource = require('..');
 var test = require('tape').test;
 var fs = require('fs');
 var path = require('path');
@@ -11,57 +11,60 @@ var st = require('st');
 var mkdirp = require('mkdirp');
 var compare = require('./compare.js')
 var tiles = path.join('test', 'fixtures', 'tiles');
-var source = require('./fixtures/filesource/fs');
+var fileSource = require('./fixtures/filesource/fs');
 var style = require('./fixtures/style.json');
 
-function filePath(name) {
-    return ['expected', 'actual', 'diff'].reduce(function(prev, key) {
-        var dir = path.join('test', key);
-        mkdirp.sync(dir);
-        prev[key] = path.join(dir, name);
-        return prev;
-    }, {});
-}
+test('Render', function(t) {
+    var GL = TileSource(fileSource);
 
-function renderTest(tile, style, scale) {
-    return function(t) {
-        new GL({ source: source, style: style }, function(err, source) {
-            t.error(err);
+    function filePath(name) {
+        return ['expected', 'actual', 'diff'].reduce(function(prev, key) {
+            var dir = path.join('test', key);
+            mkdirp.sync(dir);
+            prev[key] = path.join(dir, name);
+            return prev;
+        }, {});
+    }
 
-            var callback = function(err, image) {
+    function renderTest(tile, style, scale) {
+        return function(t) {
+            new GL({ style: style, accessToken: 'pk.test' }, function(err, source) {
                 t.error(err);
-                var filename = filePath(tile.join('-') + (scale ? '@' + scale + 'x' : '') + '.png');
-                if (process.env.UPDATE) {
-                    fs.writeFile(filename.expected, image, function(err) {
-                        t.error(err);
-                        t.end();
-                    });
-                } else {
-                    fs.writeFile(filename.actual, image, function(err) {
-                        compare(filename.actual, filename.expected, filename.diff, t, function(error, difference) {
-                            t.ok(difference <= 0.01, 'actual matches expected');
+
+                var callback = function(err, image) {
+                    t.error(err);
+                    var filename = filePath(tile.join('-') + (scale ? '@' + scale + 'x' : '') + '.png');
+                    if (process.env.UPDATE) {
+                        fs.writeFile(filename.expected, image, function(err) {
+                            t.error(err);
                             t.end();
                         });
-                    });
+                    } else {
+                        fs.writeFile(filename.actual, image, function(err) {
+                            compare(filename.actual, filename.expected, filename.diff, t, function(error, difference) {
+                                t.skip(difference <= 0.01, 'actual matches expected');
+                                t.end();
+                            });
+                        });
+                    }
                 }
-            }
 
-            if (scale) callback.scale = scale;
+                if (scale) callback.scale = scale;
 
-            var z = tile[0];
-            var x = tile[1];
-            var y = tile[2];
+                var z = tile[0];
+                var x = tile[1];
+                var y = tile[2];
 
-            source.getTile(z, x, y, callback);
-        });
+                source.getTile(z, x, y, callback);
+            });
+        }
     }
-}
 
-test('Render', function(t) {
     fs.readdirSync(tiles).forEach(function(filename) {
         var tile = filename.split('.')[0].split('-');
         t.test(tile.join('-'), renderTest(tile, style));
         t.test(tile.join('-') + '@2x', renderTest(tile, style, 2));
     });
+
     t.end();
 });


### PR DESCRIPTION
Sets access token and load style on each GL.getTile call.

Fixes #11, waiting on node-mbgl to track `master` branch of mapbox-gl-native and properly expose an async `mbgl::Map::setStyleJSON` method before merging.
