### PR TITLE
Add pooling

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,23 +72,13 @@ GL.prototype.getTile = function(z, x, y, callback) {
 GL.prototype.getStatic = function(options, callback) {
     var that = this;
     this._pool.acquire(function(err, map) {
+
         map.render(options, function(err, data) {
 
             if (err) return callback(err);
 
-            var png = new PNG({
-                width: data.width,
-                height: data.height
-            });
-
-            png.data = data.pixels;
-
-            var concatStream = concat(function(buffer) {
-                return callback(null, buffer, { 'Content-Type': 'image/png' });
-            });
-
             that._pool.release(map);
-            png.pack().pipe(concatStream);
+            return callback(null, data.pixels, { 'Content-Type': 'image/png' });
         });
     });
 };

--- a/index.js
+++ b/index.js
@@ -3,6 +3,26 @@ var mbgl = require('mapbox-gl-native');
 var PNG = require('pngjs').PNG;
 var stream = require('stream');
 var concat = require('concat-stream');
+var Pool = require('generic-pool').Pool;
+var N_CPUS = require('os').cpus().length;
+
+function pool(style, fileSource) {
+    return Pool({
+        create: create,
+        destroy: destroy,
+        max: N_CPUS
+    });
+
+    function create(callback) {
+        var map = new mbgl.Map(fileSource);
+        var loaded = map.load(style);
+        return callback(null, map);
+    }
+
+    function destroy(map) {
+        delete map;
+    }
+}
 
 module.exports = function(fileSource) {
     if (typeof fileSource.request !== 'function') throw new Error("fileSource must have a 'request' method");
@@ -20,9 +40,7 @@ function GL(options, callback) {
     if (!options.style) return callback(new Error('Missing GL style JSON'));
 
     this._scale = options.scale || 1;
-
-    this._map = new mbgl.Map(this._fileSource);
-    this._map.load(options.style);
+    this._pool = pool(options.style, this._fileSource);
 
     return callback(null, this);
 }
@@ -32,7 +50,6 @@ GL.registerProtocols = function(tilelive) {
 };
 
 GL.prototype.getTile = function(z, x, y, callback) {
-
     // Hack around tilelive API - allow params to be passed per request
     // as attributes of the callback function.
     var scale = callback.scale || this._scale;
@@ -53,20 +70,25 @@ GL.prototype.getTile = function(z, x, y, callback) {
 };
 
 GL.prototype.getStatic = function(options, callback) {
-    this._map.render(options, function(err, data) {
-        if (err) return callback(err);
+    var that = this;
+    this._pool.acquire(function(err, map) {
+        map.render(options, function(err, data) {
 
-        var png = new PNG({
-            width: data.width,
-            height: data.height
+            if (err) return callback(err);
+
+            var png = new PNG({
+                width: data.width,
+                height: data.height
+            });
+
+            png.data = data.pixels;
+
+            var concatStream = concat(function(buffer) {
+                return callback(null, buffer, { 'Content-Type': 'image/png' });
+            });
+
+            that._pool.release(map);
+            png.pack().pipe(concatStream);
         });
-
-        png.data = data.pixels;
-
-        var concatStream = concat(function(buffer) {
-            return callback(null, buffer, { 'Content-Type': 'image/png' });
-        });
-
-        png.pack().pipe(concatStream);
     });
 };

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   },
   "devDependencies": {
     "mkdirp": "^0.5.1",
-    "queue-async": "^1.0.7",
     "request": "^2.58.0",
     "st": "^0.5.4",
     "tape": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -20,12 +20,14 @@
   ],
   "dependencies": {
     "concat-stream": "^1.5.0",
+    "generic-pool": "^2.2.0",
     "mapbox-gl-native": "^1.1.1",
     "pngjs": "^0.4.0",
     "sphericalmercator": "^1.0.3"
   },
   "devDependencies": {
     "mkdirp": "^0.5.1",
+    "queue-async": "^1.0.7",
     "request": "^2.58.0",
     "st": "^0.5.4",
     "tape": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "mkdirp": "^0.5.1",
+    "queue-async": "^1.0.7",
     "request": "^2.58.0",
     "st": "^0.5.4",
     "tape": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "concat-stream": "^1.5.0",
     "generic-pool": "^2.2.0",
-    "mapbox-gl-native": "^1.1.1",
+    "mapbox-gl-native": "https://github.com/mapbox/node-mapbox-gl-native/tarball/native_png_encoder",
     "pngjs": "^0.4.0",
     "sphericalmercator": "^1.0.3"
   },

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -13,10 +13,12 @@ var compare = require('./compare.js')
 var tiles = ['0-0-0', '1-0-1', '2-1-1', '3-2-3', '4-4-6'];
 var fileSource = require('./lib/fs');
 var style = require('./fixtures/style.json');
+var queue = require('queue-async');
 
 test('Render', function(t) {
     var GL = TileSource(fileSource);
     var mbgl = TileSource.mbgl;
+    var testQueue = new queue(1);
 
     mbgl.on('message', function(msg) {
         console.log(msg);
@@ -31,44 +33,60 @@ test('Render', function(t) {
         }, {});
     }
 
-    function renderTest(style, scale, t) {
+    function renderTest(style, scale, t, callback) {
         new GL({ style: style }, function(err, source) {
             t.error(err);
+            var q = new queue();
 
             tiles.forEach(function(tile) {
-                var cb = function(err, image) {
-                    if (err) {
-                        t.error(err);
-                        return callback(err);
-                    }
+                tile = tile.split('-');
 
-                    var filename = filePath(tile.join('-') + (scale ? '@' + scale + 'x' : '') + '.png');
-                    if (process.env.UPDATE) {
-                        fs.writeFile(filename.expected, image, function(err) {
+                var getTile = function(z, x, y, callback) {
+                    var cb = function(err, image){
+                        if (err) {
                             t.error(err);
-                            return callback();
-                        });
-                    } else {
-                        fs.writeFile(filename.actual, image, function(err) {
-                            compare(filename.actual, filename.expected, filename.diff, t, function(error, difference) {
-                                t.ok(difference <= 0.01, 'actual matches expected');
+                            return callback(err);
+                        }
+
+                        var filename = filePath(tile.join('-') + (scale ? '@' + scale + 'x' : '') + '.png');
+
+                        if (process.env.UPDATE) {
+                            fs.writeFile(filename.expected, image, function(err) {
+                                t.error(err);
                                 return callback();
                             });
-                        });
-                    }
+                        } else {
+                            fs.writeFile(filename.actual, image, function(err) {
+                                compare(filename.actual, filename.expected, filename.diff, t, function(error, difference) {
+                                    t.ok(difference <= 0.01, 'actual matches expected');
+                                    return callback();
+                                });
+                            });
+                        }
+                    };
+                    if (scale) cb.scale = scale;
+                    source.getTile(z, x, y, cb);
                 };
-
-                if (scale) cb.scale = scale;
 
                 var z = tile[0];
                 var x = tile[1];
                 var y = tile[2];
 
-                source.getTile(z, x, y, cb);
+                q.defer(getTile, z, x, y);
+
+                q.awaitAll(function(err, res){
+                    if (err) return callback(err);
+                    return callback();
+                });
             });
         });
     }
 
-    renderTest(style, 2, t);
+    testQueue.defer(renderTest, style, null, t);
+    testQueue.defer(renderTest, style, 2, t);
+
+    testQueue.awaitAll(function(){
+        t.end();
+    });
 
 });

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -13,7 +13,6 @@ var compare = require('./compare.js')
 var tiles = ['0-0-0', '1-0-1', '2-1-1', '3-2-3', '4-4-6'];
 var fileSource = require('./lib/fs');
 var style = require('./fixtures/style.json');
-var queue = require('queue-async');
 
 test('Render', function(t) {
     var GL = TileSource(fileSource);
@@ -47,12 +46,12 @@ test('Render', function(t) {
                     if (process.env.UPDATE) {
                         fs.writeFile(filename.expected, image, function(err) {
                             t.error(err);
-                            return callback(err);
+                            return callback();
                         });
                     } else {
                         fs.writeFile(filename.actual, image, function(err) {
                             compare(filename.actual, filename.expected, filename.diff, t, function(error, difference) {
-                                t.ok(difference <= 0.1, 'actual matches expected');
+                                t.ok(difference <= 0.01, 'actual matches expected');
                                 return callback();
                             });
                         });


### PR DESCRIPTION
@jfirebaugh @mikemorris I see that pooling has been added and removed once now from tilelive-gl. I added this here so that multiple requests can come into tilelive-gl. Somewhere, concurrency needs to be handled and from what I'm seeing, we're not adding it node-mapbox-gl-native.

/cc @yhahn @tmpsantos 
