### PR TITLE
Add link to maintained fork in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 This project is deprecated and no longer maintained. Use [mapbox-gl-native](https://www.npmjs.com/package/mapbox-gl-native) directly instead.
+
+A fork of this project is being maintained by a third party at [trailbehind/tilelive-gl](https://github.com/trailbehind/tilelive-gl).


### PR DESCRIPTION
I have forked this project and updated it so that it runs with the latest version of node-mapbox-gl-native, would you consider adding a link to my fork to the README so people who stumble on this repo can find my fork?